### PR TITLE
replace deprecated call, other small fixes

### DIFF
--- a/src/main/java/redis/embedded/util/JarUtil.java
+++ b/src/main/java/redis/embedded/util/JarUtil.java
@@ -1,11 +1,11 @@
 package redis.embedded.util;
 
-import com.google.common.io.Files;
 import com.google.common.io.Resources;
 import org.apache.commons.io.FileUtils;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 
 public class JarUtil {
 
@@ -17,7 +17,7 @@ public class JarUtil {
     }
 
     public static File extractFileFromJar(String path) throws IOException {
-        File tmpDir = Files.createTempDir();
+        File tmpDir = Files.createTempDirectory(null).toFile();
         tmpDir.deleteOnExit();
 
         File file = new File(tmpDir, path);

--- a/src/test/java/redis/embedded/RedisClusterTest.java
+++ b/src/test/java/redis/embedded/RedisClusterTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -301,7 +302,7 @@ public class RedisClusterTest {
         //then
         assertEquals("1", jedis.mget("abc").get(0));
         assertEquals("2", jedis.mget("def").get(0));
-        assertEquals(null, jedis.mget("xyz").get(0));
+        assertNull(jedis.mget("xyz").get(0));
         return jedis;
     }
 

--- a/src/test/java/redis/embedded/RedisServerClusterTest.java
+++ b/src/test/java/redis/embedded/RedisServerClusterTest.java
@@ -7,6 +7,7 @@ import redis.clients.jedis.Jedis;
 import redis.clients.jedis.JedisPool;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class RedisServerClusterTest {
 
@@ -39,7 +40,7 @@ public class RedisServerClusterTest {
 
             assertEquals("1", jedis.mget("abc").get(0));
             assertEquals("2", jedis.mget("def").get(0));
-            assertEquals(null, jedis.mget("xyz").get(0));
+            assertNull(jedis.mget("xyz").get(0));
         } finally {
             if (jedis != null)
                 pool.returnResource(jedis);

--- a/src/test/java/redis/embedded/ports/EphemeralPortProviderTest.java
+++ b/src/test/java/redis/embedded/ports/EphemeralPortProviderTest.java
@@ -16,7 +16,7 @@ public class EphemeralPortProviderTest {
         final EphemeralPortProvider provider = new EphemeralPortProvider();
 
         //when
-        final List<Integer> ports = new ArrayList<Integer>();
+        final List<Integer> ports = new ArrayList<>();
         for(int i = 0;i < portCount; i++) {
             ports.add(provider.next());
         }

--- a/src/test/java/redis/embedded/ports/PredefinedPortProviderTest.java
+++ b/src/test/java/redis/embedded/ports/PredefinedPortProviderTest.java
@@ -19,7 +19,7 @@ public class PredefinedPortProviderTest {
         final PredefinedPortProvider provider = new PredefinedPortProvider(ports);
 
         //when
-        final List<Integer> returnedPorts = new ArrayList<Integer>();
+        final List<Integer> returnedPorts = new ArrayList<>();
         for(int i = 0;i < ports.size(); i++) {
             returnedPorts.add(provider.next());
         }


### PR DESCRIPTION
- replace deprecated call to Guava's `Files.createTempDir()`
- simplify `assertEquals(null, ...)` to `assertNull(...)`
- remove redundant generic type specifications